### PR TITLE
Lower MIN_PERL_VERSION from 5.38.0 to 5.26.0

### DIFF
--- a/.github/workflows/perltest.yml
+++ b/.github/workflows/perltest.yml
@@ -12,7 +12,7 @@ jobs:
     uses: PerlToolsTeam/github_workflows/.github/workflows/cpan-test.yml@main
     with:
       os: "[ 'ubuntu-latest', 'macos-latest' ]"
-      perl_version: "[ 'latest' ]"
+      perl_version: "[ '5.26', '5.28', '5.30', '5.32', '5.34', '5.36', '5.38', '5.40', '5.42' ]"
 
   coverage:
     uses: PerlToolsTeam/github_workflows/.github/workflows/cpan-coverage.yml@main

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,18 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Lower `MIN_PERL_VERSION` from 5.38.0 to 5.26.0. The module itself only needs
+  Perl 5.10, and its only non-core prerequisite (`WebServer::DirIndex`)
+  supports Perl 5.26+, so the 5.38 floor was unnecessarily excluding usable
+  Perl versions.
+
+### Changed
+
+- CI now tests across Perl 5.26 through 5.42 (previously only `latest`), so the
+  declared `MIN_PERL_VERSION` is actually exercised.
+
 ## [0.2.2] - 2026-03-12
 
 ### Fixed

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
   NAME              => 'Plack::App::DirectoryIndex',
   VERSION_FROM      => 'lib/Plack/App/DirectoryIndex.pm',
-  MIN_PERL_VERSION  => '5.38.0',
+  MIN_PERL_VERSION  => '5.26.0',
   PREREQ_PM         => {
     Plack                => 0,
     'WebServer::DirIndex' => '0.1.4',


### PR DESCRIPTION
## Summary

`Makefile.PL` declares `MIN_PERL_VERSION => '5.38.0'`, but nothing in this distribution actually requires Perl 5.38. This lowers the floor to the real minimum, **5.26.0**.

## Why the 5.38 floor is wrong

- **The code only needs Perl 5.10.** `lib/Plack/App/DirectoryIndex.pm` uses only `strict`, `warnings`, `parent`, and the `//` operator (5.10+) — no signatures, no `class`, no 5.36/5.38 features.
- **The only non-core prerequisite is `WebServer::DirIndex`, which supports Perl 5.26+.** It uses `Feature::Compat::Class`, which needs 5.26 — so 5.26.0 is the true effective minimum of the dependency chain.
- **It was never deliberate.** The `5.38.0` was baked into `Makefile.PL` when the dist was restructured at v0.1.0 (extracting `WebServer::DirIndex`); no changelog entry ever documented a Perl-version requirement.
- **CI never caught it** because the matrix only tested `latest`.

## Impact

The over-tight floor broke downstream consumers. For example, `App-HTTPThis` (which requires `Plack::App::DirectoryIndex`) fails to install on every Perl older than 5.38:

```
! Installing the dependencies failed: Your Perl (5.030003) is not in the range '5.038000'
! Bailing out the installation for Plack-App-DirectoryIndex-v0.2.3.
```

## Changes

- `Makefile.PL`: `MIN_PERL_VERSION` 5.38.0 -> 5.26.0.
- `.github/workflows/perltest.yml`: test Perl 5.26-5.42 (was `latest` only) so the declared minimum is actually exercised and this can't silently regress.
- `Changes.md`: changelog entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>